### PR TITLE
Add new SVG charts for price history and forecast

### DIFF
--- a/src/lib/mcp_server/mcp_server/charts/670eaf2bb7eab53d.svg
+++ b/src/lib/mcp_server/mcp_server/charts/670eaf2bb7eab53d.svg
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" viewBox="0 0 800 400">
+    <rect x="0" y="0" width="800" height="400" fill="#1a1a1a" />
+    
+      <line x1="64.80" y1="158.69" x2="64.80" y2="158.76" stroke="#00ff88" stroke-width="1" />
+      <rect x="61.20" y="158.70" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="76.80" y1="147.51" x2="76.80" y2="147.77" stroke="#00ff88" stroke-width="1" />
+      <rect x="73.20" y="147.69" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="88.80" y1="144.48" x2="88.80" y2="144.87" stroke="#ff4444" stroke-width="1" />
+      <rect x="85.20" y="144.49" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="100.80" y1="104.87" x2="100.80" y2="105.46" stroke="#ff4444" stroke-width="1" />
+      <rect x="97.20" y="104.96" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="112.80" y1="108.62" x2="112.80" y2="109.19" stroke="#00ff88" stroke-width="1" />
+      <rect x="109.20" y="109.00" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="124.80" y1="85.04" x2="124.80" y2="85.41" stroke="#00ff88" stroke-width="1" />
+      <rect x="121.20" y="85.15" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="136.80" y1="91.36" x2="136.80" y2="91.78" stroke="#ff4444" stroke-width="1" />
+      <rect x="133.20" y="91.32" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="148.80" y1="106.14" x2="148.80" y2="106.41" stroke="#ff4444" stroke-width="1" />
+      <rect x="145.20" y="105.91" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="160.80" y1="93.58" x2="160.80" y2="93.65" stroke="#ff4444" stroke-width="1" />
+      <rect x="157.20" y="93.52" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="172.80" y1="111.03" x2="172.80" y2="111.29" stroke="#ff4444" stroke-width="1" />
+      <rect x="169.20" y="110.71" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="184.80" y1="98.91" x2="184.80" y2="99.31" stroke="#00ff88" stroke-width="1" />
+      <rect x="181.20" y="98.97" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="196.80" y1="106.95" x2="196.80" y2="107.01" stroke="#00ff88" stroke-width="1" />
+      <rect x="193.20" y="106.98" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="208.80" y1="106.62" x2="208.80" y2="107.14" stroke="#ff4444" stroke-width="1" />
+      <rect x="205.20" y="106.57" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="220.80" y1="106.84" x2="220.80" y2="107.15" stroke="#00ff88" stroke-width="1" />
+      <rect x="217.20" y="107.08" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="232.80" y1="85.64" x2="232.80" y2="86.12" stroke="#ff4444" stroke-width="1" />
+      <rect x="229.20" y="85.72" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="244.80" y1="118.40" x2="244.80" y2="118.90" stroke="#00ff88" stroke-width="1" />
+      <rect x="241.20" y="118.68" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="256.80" y1="158.48" x2="256.80" y2="158.99" stroke="#00ff88" stroke-width="1" />
+      <rect x="253.20" y="158.68" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="268.80" y1="199.46" x2="268.80" y2="199.98" stroke="#00ff88" stroke-width="1" />
+      <rect x="265.20" y="199.73" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="280.80" y1="234.41" x2="280.80" y2="234.95" stroke="#00ff88" stroke-width="1" />
+      <rect x="277.20" y="234.71" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="292.80" y1="257.38" x2="292.80" y2="257.75" stroke="#00ff88" stroke-width="1" />
+      <rect x="289.20" y="257.71" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="304.80" y1="265.21" x2="304.80" y2="265.69" stroke="#ff4444" stroke-width="1" />
+      <rect x="301.20" y="265.28" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="316.80" y1="272.66" x2="316.80" y2="273.16" stroke="#ff4444" stroke-width="1" />
+      <rect x="313.20" y="272.68" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="328.80" y1="236.70" x2="328.80" y2="236.84" stroke="#ff4444" stroke-width="1" />
+      <rect x="325.20" y="236.73" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="340.80" y1="222.93" x2="340.80" y2="223.32" stroke="#ff4444" stroke-width="1" />
+      <rect x="337.20" y="222.91" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="352.80" y1="239.15" x2="352.80" y2="239.19" stroke="#ff4444" stroke-width="1" />
+      <rect x="349.20" y="238.97" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="364.80" y1="245.53" x2="364.80" y2="245.98" stroke="#ff4444" stroke-width="1" />
+      <rect x="361.20" y="245.54" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="376.80" y1="248.59" x2="376.80" y2="248.90" stroke="#00ff88" stroke-width="1" />
+      <rect x="373.20" y="248.82" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="388.80" y1="272.40" x2="388.80" y2="273.03" stroke="#ff4444" stroke-width="1" />
+      <rect x="385.20" y="272.71" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="400.80" y1="309.88" x2="400.80" y2="310.31" stroke="#00ff88" stroke-width="1" />
+      <rect x="397.20" y="310.12" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="412.80" y1="275.64" x2="412.80" y2="276.13" stroke="#ff4444" stroke-width="1" />
+      <rect x="409.20" y="275.84" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="424.80" y1="261.26" x2="424.80" y2="261.53" stroke="#ff4444" stroke-width="1" />
+      <rect x="421.20" y="261.36" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="436.80" y1="255.54" x2="436.80" y2="255.87" stroke="#00ff88" stroke-width="1" />
+      <rect x="433.20" y="255.72" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="448.80" y1="275.35" x2="448.80" y2="275.47" stroke="#00ff88" stroke-width="1" />
+      <rect x="445.20" y="275.38" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="460.80" y1="306.58" x2="460.80" y2="307.04" stroke="#00ff88" stroke-width="1" />
+      <rect x="457.20" y="306.87" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="472.80" y1="296.84" x2="472.80" y2="297.16" stroke="#00ff88" stroke-width="1" />
+      <rect x="469.20" y="297.09" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="484.80" y1="319.42" x2="484.80" y2="319.65" stroke="#00ff88" stroke-width="1" />
+      <rect x="481.20" y="319.49" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="496.80" y1="309.84" x2="496.80" y2="310.33" stroke="#00ff88" stroke-width="1" />
+      <rect x="493.20" y="310.08" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="508.80" y1="310.63" x2="508.80" y2="311.10" stroke="#00ff88" stroke-width="1" />
+      <rect x="505.20" y="310.91" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="520.80" y1="271.85" x2="520.80" y2="272.28" stroke="#00ff88" stroke-width="1" />
+      <rect x="517.20" y="272.16" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="532.80" y1="259.57" x2="532.80" y2="259.96" stroke="#ff4444" stroke-width="1" />
+      <rect x="529.20" y="259.60" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="544.80" y1="254.43" x2="544.80" y2="254.74" stroke="#00ff88" stroke-width="1" />
+      <rect x="541.20" y="254.67" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="556.80" y1="280.99" x2="556.80" y2="281.27" stroke="#00ff88" stroke-width="1" />
+      <rect x="553.20" y="281.24" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="568.80" y1="276.76" x2="568.80" y2="277.15" stroke="#ff4444" stroke-width="1" />
+      <rect x="565.20" y="277.00" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="580.80" y1="249.23" x2="580.80" y2="249.48" stroke="#00ff88" stroke-width="1" />
+      <rect x="577.20" y="249.26" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="592.80" y1="292.40" x2="592.80" y2="292.78" stroke="#00ff88" stroke-width="1" />
+      <rect x="589.20" y="292.53" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="604.80" y1="281.19" x2="604.80" y2="281.29" stroke="#00ff88" stroke-width="1" />
+      <rect x="601.20" y="281.25" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="616.80" y1="293.58" x2="616.80" y2="293.86" stroke="#ff4444" stroke-width="1" />
+      <rect x="613.20" y="293.66" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="628.80" y1="311.10" x2="628.80" y2="311.48" stroke="#ff4444" stroke-width="1" />
+      <rect x="625.20" y="310.90" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="640.80" y1="296.00" x2="640.80" y2="296.17" stroke="#ff4444" stroke-width="1" />
+      <rect x="637.20" y="295.98" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="652.80" y1="265.37" x2="652.80" y2="265.53" stroke="#00ff88" stroke-width="1" />
+      <rect x="649.20" y="265.48" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="664.80" y1="241.02" x2="664.80" y2="241.32" stroke="#00ff88" stroke-width="1" />
+      <rect x="661.20" y="241.16" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="676.80" y1="230.83" x2="676.80" y2="231.26" stroke="#ff4444" stroke-width="1" />
+      <rect x="673.20" y="230.61" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="688.80" y1="240.55" x2="688.80" y2="240.98" stroke="#ff4444" stroke-width="1" />
+      <rect x="685.20" y="240.60" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="700.80" y1="241.11" x2="700.80" y2="241.65" stroke="#00ff88" stroke-width="1" />
+      <rect x="697.20" y="241.42" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+
+      <line x1="712.80" y1="243.37" x2="712.80" y2="243.73" stroke="#ff4444" stroke-width="1" />
+      <rect x="709.20" y="243.22" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="724.80" y1="257.01" x2="724.80" y2="257.09" stroke="#ff4444" stroke-width="1" />
+      <rect x="721.20" y="256.70" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="736.80" y1="282.20" x2="736.80" y2="282.64" stroke="#ff4444" stroke-width="1" />
+      <rect x="733.20" y="282.32" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="748.80" y1="277.62" x2="748.80" y2="278.01" stroke="#ff4444" stroke-width="1" />
+      <rect x="745.20" y="277.50" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="760.80" y1="275.63" x2="760.80" y2="276.04" stroke="#ff4444" stroke-width="1" />
+      <rect x="757.20" y="275.85" width="7.20" height="1.00" fill="#ff4444" stroke="#ff4444" stroke-width="1" />
+    
+
+      <line x1="772.80" y1="278.39" x2="772.80" y2="278.77" stroke="#00ff88" stroke-width="1" />
+      <rect x="769.20" y="278.70" width="7.20" height="1.00" fill="#00ff88" stroke="#00ff88" stroke-width="1" />
+    
+    <text x="400" y="25" fill="#fff" font-size="14" text-anchor="middle">Price History (Candlestick - Last 60 Days)</text>
+    <text x="50" y="364.00" fill="#fff" font-size="12" text-anchor="end">$0.16</text>
+<text x="50" y="300.00" fill="#fff" font-size="12" text-anchor="end">$0.16</text>
+<text x="50" y="236.00" fill="#fff" font-size="12" text-anchor="end">$0.17</text>
+<text x="50" y="172.00" fill="#fff" font-size="12" text-anchor="end">$0.17</text>
+<text x="50" y="108.00" fill="#fff" font-size="12" text-anchor="end">$0.18</text>
+<text x="50" y="44.00" fill="#fff" font-size="12" text-anchor="end">$0.18</text>
+  </svg>

--- a/src/lib/mcp_server/mcp_server/charts/9ebdecd15b033def.svg
+++ b/src/lib/mcp_server/mcp_server/charts/9ebdecd15b033def.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" viewBox="0 0 800 400">
+    <rect x="0" y="0" width="800" height="400" fill="#1a1a1a" />
+    <line x1="60" y1="40.00" x2="780" y2="40.00" stroke="#333" stroke-width="1" />
+<line x1="60" y1="104.00" x2="780" y2="104.00" stroke="#333" stroke-width="1" />
+<line x1="60" y1="168.00" x2="780" y2="168.00" stroke="#333" stroke-width="1" />
+<line x1="60" y1="232.00" x2="780" y2="232.00" stroke="#333" stroke-width="1" />
+<line x1="60" y1="296.00" x2="780" y2="296.00" stroke="#333" stroke-width="1" />
+<line x1="60" y1="360.00" x2="780" y2="360.00" stroke="#333" stroke-width="1" />
+    <polygon points="660.00,-1.92 680.00,45.67 700.00,4.17 720.00,-15.35 740.00,11.92 760.00,44.09 780.00,38.50 780.00,421.48 760.00,426.53 740.00,397.43 720.00,372.75 700.00,390.42 680.00,427.97 660.00,384.90" fill="rgba(0,150,255,0.1)" />
+    <polyline fill="none" stroke="#00ff88" stroke-width="2" points="60.00,175.99 80.00,165.17 100.00,201.96 120.00,260.90 140.00,242.58 160.00,284.49 180.00,266.89 200.00,268.45 220.00,195.94 240.00,172.82 260.00,163.21 280.00,212.93 300.00,205.11 320.00,153.09 340.00,234.06 360.00,212.95 380.00,236.33 400.00,269.04 420.00,240.58 440.00,183.43 460.00,137.92 480.00,118.82 500.00,137.17 520.00,138.42 540.00,142.39 560.00,167.64 580.00,215.14 600.00,206.46 620.00,203.00 640.00,208.18" />
+    <polyline fill="none" stroke="#0088ff" stroke-dasharray="5,5" stroke-width="2" points="660.00,191.49 680.00,236.82 700.00,197.30 720.00,178.70 740.00,204.67 760.00,235.31 780.00,229.99" />
+    <text x="400" y="25" fill="#fff" font-size="14" text-anchor="middle">Price Forecast</text>
+    <text x="50" y="364.00" fill="#fff" font-size="12" text-anchor="end">$0.16</text>
+<text x="50" y="300.00" fill="#fff" font-size="12" text-anchor="end">$0.16</text>
+<text x="50" y="236.00" fill="#fff" font-size="12" text-anchor="end">$0.16</text>
+<text x="50" y="172.00" fill="#fff" font-size="12" text-anchor="end">$0.17</text>
+<text x="50" y="108.00" fill="#fff" font-size="12" text-anchor="end">$0.17</text>
+<text x="50" y="44.00" fill="#fff" font-size="12" text-anchor="end">$0.17</text>
+    
+    <text x="630" y="50" fill="#00ff88" font-size="12">● Historical</text>
+    <text x="630" y="70" fill="#0088ff" font-size="12">● Forecast</text>
+  
+  </svg>


### PR DESCRIPTION
- Introduced a new SVG file for price history with candlestick representation over the last 60 days.
- Updated the existing SVG for price forecast with improved visual elements and annotations.
- Enhanced color coding for better distinction between historical and forecast data.